### PR TITLE
AppendErrors confusion fix

### DIFF
--- a/src/OneBitSoftware.Utilities.OperationResult/OneBitSoftware.Utilities.OperationResult.csproj
+++ b/src/OneBitSoftware.Utilities.OperationResult/OneBitSoftware.Utilities.OperationResult.csproj
@@ -32,7 +32,7 @@
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>OneBitSoftware; OperationResult;</PackageTags>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/OneBitSoftware.Utilities.OperationResult/OperationResult.cs
+++ b/src/OneBitSoftware.Utilities.OperationResult/OperationResult.cs
@@ -305,15 +305,26 @@
         }
 
         /// <summary>
-        /// Appends error messages from <paramref name="otherOperationResult"/> to <paramref name="originalOperationResult"/>.
+        /// Appends error messages from <paramref name="otherOperationResult"/> to the current instance.
         /// </summary>
-        /// <param name="originalOperationResult">The <see cref="OperationResult"/> to append to.</param>
         /// <param name="otherOperationResult">The <see cref="OperationResult"/> to append from.</param>
-        /// <typeparam name="TOriginal">A type that inherits from <see cref="OperationResult"/>.</typeparam>
         /// <typeparam name="TOther">A type that inherits from <see cref="OperationResult"/>.</typeparam>
         /// <returns>The original <see cref="OperationResult"/> with the appended messages from <paramref name="otherOperationResult"/>.</returns>
+        [Obsolete("Please use AppendErrors instead. This method will be removed to avoid confusion.")]
         public OperationResult<TResult> AppendErrorMessages<TOther>(TOther otherOperationResult)
             where TOther : OperationResult
+        {
+            base.AppendErrors(otherOperationResult);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Appends error from <paramref name="otherOperationResult"/> to the current instance.
+        /// </summary>
+        /// <param name="otherOperationResult">The <see cref="OperationResult"/> to append from.</param>
+        /// <returns>The original <see cref="OperationResult"/> with the appended messages from <paramref name="otherOperationResult"/>.</returns>
+        public new OperationResult<TResult> AppendErrors(OperationResult otherOperationResult)
         {
             base.AppendErrors(otherOperationResult);
 

--- a/tests/OneBitSoftware.Utilities.OperationResultTests/OperationResultAppendErrorsTests.cs
+++ b/tests/OneBitSoftware.Utilities.OperationResultTests/OperationResultAppendErrorsTests.cs
@@ -61,6 +61,40 @@ public class OperationResultAppendErrorsTests
         var operationResultBase = new OperationResult<object>();
         operationResultBase.AppendError(message2, errorCode2, LogLevel.Debug, detail2);
 
+        // Act - AppendErrorMessages is to be removed
+        operationResultBase.AppendErrorMessages(operationResultTarget);
+
+        // Assert
+        Assert.False(operationResultBase.Success);
+        Assert.False(operationResultTarget.Success);
+        Assert.True(operationResultBase.Fail);
+        Assert.True(operationResultTarget.Fail);
+
+        Assert.Equal(3, operationResultBase.Errors.Count);
+        Assert.Equal(2, operationResultTarget.Errors.Count);
+
+        Assert.NotNull(operationResultBase.Errors.Single(r => r.Code.Equals(errorCode2)));
+        Assert.NotNull(operationResultBase.Errors.Single(r => r.Message.Equals(message2)));
+        Assert.NotNull(operationResultBase.Errors.Single(r => r.Details is not null && r.Details.Equals(detail2)));
+    }
+
+    [Fact]
+    public void AppendErrorsStringInt_ShouldListAllErrors()
+    {
+        // Arrange
+        var errorCode1 = 666;
+        var message1 = "Error";
+        var detail1 = "Detail";
+        var operationResultTarget = new OperationResult<int>();
+        operationResultTarget.AppendError(message1, errorCode1, LogLevel.Debug, detail1);
+        operationResultTarget.AppendException(new Exception(message1));
+
+        var errorCode2 = 669;
+        var message2 = "Error2";
+        var detail2 = "Detail2";
+        var operationResultBase = new OperationResult<string>();
+        operationResultBase.AppendError(message2, errorCode2, LogLevel.Debug, detail2);
+
         // Act
         operationResultBase.AppendErrors(operationResultTarget);
 


### PR DESCRIPTION
We are removing AppendErrorMessages in the generic type as it just confuses people with AppendErrors in the base type.